### PR TITLE
feat: 채용 공고 삭제 API 구현

### DIFF
--- a/src/main/java/com/wanted/preonboarding/jobpost/controller/JobPostController.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/controller/JobPostController.java
@@ -4,6 +4,7 @@ import com.wanted.preonboarding.common.ApiResponse;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostCreateRequest;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostUpdateRequest;
 import com.wanted.preonboarding.jobpost.service.JobPostService;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,6 +31,12 @@ public class JobPostController {
     public ApiResponse<?> updateJobPost(@RequestBody @Valid JobPostUpdateRequest jobPostUpdateRequest,
                                         @PathVariable Long jobPostId) {
         jobPostService.updateJobPost(jobPostUpdateRequest, jobPostId);
+        return ApiResponse.succeed();
+    }
+
+    @DeleteMapping("/job-post/{jobPostId}")
+    public ApiResponse<?> deleteJobPost(@PathVariable Long jobPostId) {
+        jobPostService.deleteJobPost(jobPostId);
         return ApiResponse.succeed();
     }
 }

--- a/src/main/java/com/wanted/preonboarding/jobpost/entity/JobPost.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/entity/JobPost.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -18,6 +19,7 @@ import javax.persistence.ManyToOne;
 
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE job_post SET is_deleted = true WHERE id = ?")
 @EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JobPost extends BaseTimeEntity {

--- a/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
@@ -43,4 +43,11 @@ public class JobPostService {
         jobPost.update(newJobPost);
         jobPostRepository.save(jobPost);
     }
+
+    @Transactional
+    public void deleteJobPost(long jobPostId) {
+        JobPost jobPost = jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)
+                                           .orElseThrow(() -> new ApplicationException(ErrorCode.JOBPOST_NOT_FOUND));
+        jobPostRepository.delete(jobPost);
+    }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+
+  h2:
+    console:
+      enabled: true

--- a/src/test/java/com/wanted/preonboarding/common/RepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/common/RepositoryTest.java
@@ -1,0 +1,9 @@
+package com.wanted.preonboarding.common;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+public abstract class RepositoryTest {
+}

--- a/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
@@ -48,7 +48,7 @@ public class JobPostRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @DisplayName("채용 공고를 삭제하면 isDeleted가 true로 바뀌어야 한다 ")
+    @DisplayName("채용 공고를 삭제하면 isDeleted가 true로 바뀌어야 한다")
     void softDeleteJobPostTest() {
         // given: 삭제되지 않은 채용 공고의 isDeleted 값은 false
         companyRepository.save(company);
@@ -66,5 +66,22 @@ public class JobPostRepositoryTest extends RepositoryTest {
                 () -> assertThat(deletedJobPost.get()
                                                .isDeleted()).isEqualTo(true)
         );
+    }
+
+    @Test
+    @DisplayName("존재하는 채용 공고 단건 조회 함수는 삭제되지 않은 채용 공고를 조회한다")
+    void findByIdAndIsDeletedFalse() {
+        // given
+        companyRepository.save(company);
+        jobPostRepository.save(jobPost);
+
+        // when: 채용 공고를 삭제 후 findByIdAndIsDeletedFalse로 조회하면
+        jobPostRepository.delete(jobPost);
+        jobPostRepository.findByIdAndIsDeletedFalse(jobPost.getId());
+        entityManager.flush();
+        Optional<JobPost> result = jobPostRepository.findByIdAndIsDeletedFalse(jobPost.getId());
+
+        // then: 조회되지 않아야 한다
+        assertThat(result.isEmpty()).isEqualTo(true);
     }
 }

--- a/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.wanted.preonboarding.jobpost.repository;
+
+import com.wanted.preonboarding.common.RepositoryTest;
+import com.wanted.preonboarding.company.entity.Company;
+import com.wanted.preonboarding.company.repository.CompanyRepository;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+public class JobPostRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @Autowired
+    private JobPostRepository jobPostRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Company company;
+    private JobPost jobPost;
+
+    @BeforeEach
+    void beforeEach() {
+        company = Company.builder()
+                         .name("카카오")
+                         .nation("한국")
+                         .region("경기도")
+                         .build();
+
+        jobPost = JobPost.builder()
+                         .company(company)
+                         .position("프론트엔드 개발")
+                         .reward(2500000L)
+                         .skills("JavaScript, React")
+                         .description("카카오에서 프론트엔드 개발자를 채용합니다.")
+                         .build();
+    }
+
+    @Test
+    @DisplayName("채용 공고를 삭제하면 isDeleted가 true로 바뀌어야 한다 ")
+    void softDeleteJobPostTest() {
+        // given: 삭제되지 않은 채용 공고의 isDeleted 값은 false
+        companyRepository.save(company);
+        jobPostRepository.save(jobPost);
+        assertThat(jobPost.isDeleted()).isEqualTo(false);
+
+        // when: 채용 공고 삭제 후 findById로 조회해보면
+        jobPostRepository.delete(jobPost);
+        entityManager.flush();
+        Optional<JobPost> deletedJobPost = jobPostRepository.findById(jobPost.getId());
+
+        // then: 삭제된 채용 공고의 isDeleted는 true로 바뀌어야 한다
+        assertAll(
+                () -> assertThat(deletedJobPost.get()).isEqualTo(jobPost),
+                () -> assertThat(deletedJobPost.get()
+                                               .isDeleted()).isEqualTo(true)
+        );
+    }
+}


### PR DESCRIPTION
## 📃 설명

- resolves #6 
- 

## 🔨 작업 내용

1. @SQLDelete 적용해서 채용 공고 soft delete 구현
2. 채용 공고 삭제 Service Layer 성공, 실패 단위 테스트 작성
3. Repository Layer soft delete, 존재하는 채용 공고 단건 조회 테스트 작성
4. test profile 환경 설정 파일 추가

## 💬 기타 사항

- 