### PR TITLE
feat: 채용 공고 지원 API 구현

### DIFF
--- a/src/main/java/com/wanted/preonboarding/applyjob/controller/ApplyJobController.java
+++ b/src/main/java/com/wanted/preonboarding/applyjob/controller/ApplyJobController.java
@@ -1,0 +1,25 @@
+package com.wanted.preonboarding.applyjob.controller;
+
+import com.wanted.preonboarding.applyjob.dto.request.ApplyJobCreateRequest;
+import com.wanted.preonboarding.applyjob.service.ApplyJobService;
+import com.wanted.preonboarding.common.ApiResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+public class ApplyJobController {
+    private final ApplyJobService applyJobService;
+
+    public ApplyJobController(final ApplyJobService applyJobService) {
+        this.applyJobService = applyJobService;
+    }
+
+    @PostMapping("/job-post/apply")
+    public ApiResponse<?> applyJobPost(@RequestBody @Valid ApplyJobCreateRequest applyJobCreateRequest) {
+        applyJobService.applyJobPost(applyJobCreateRequest);
+        return ApiResponse.succeed();
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/applyjob/dto/request/ApplyJobCreateRequest.java
+++ b/src/main/java/com/wanted/preonboarding/applyjob/dto/request/ApplyJobCreateRequest.java
@@ -1,0 +1,22 @@
+package com.wanted.preonboarding.applyjob.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@Getter
+public class ApplyJobCreateRequest {
+    @Min(0)
+    @Max(Long.MAX_VALUE)
+    private Long jobPostId;
+
+    @Min(0)
+    @Max(Long.MAX_VALUE)
+    private Long memberId;
+
+    public ApplyJobCreateRequest(Long jobPostId, Long memberId) {
+        this.jobPostId = jobPostId;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/applyjob/entity/ApplyJob.java
+++ b/src/main/java/com/wanted/preonboarding/applyjob/entity/ApplyJob.java
@@ -4,6 +4,7 @@ import com.wanted.preonboarding.common.entity.BaseCreatedTimeEntity;
 import com.wanted.preonboarding.jobpost.entity.JobPost;
 import com.wanted.preonboarding.member.entity.Member;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,4 +34,9 @@ public class ApplyJob extends BaseCreatedTimeEntity {
     @JoinColumn(nullable = false, name = "job_post_id")
     private JobPost jobPost;
 
+    @Builder
+    public ApplyJob(Member member, JobPost jobPost) {
+        this.member = member;
+        this.jobPost = jobPost;
+    }
 }

--- a/src/main/java/com/wanted/preonboarding/applyjob/repository/ApplyJobRepository.java
+++ b/src/main/java/com/wanted/preonboarding/applyjob/repository/ApplyJobRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.preonboarding.applyjob.repository;
+
+import com.wanted.preonboarding.applyjob.entity.ApplyJob;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
+import com.wanted.preonboarding.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplyJobRepository extends JpaRepository<ApplyJob, Long> {
+    Optional<ApplyJob> findByJobPostAndMember(JobPost jobPost, Member member);
+}

--- a/src/main/java/com/wanted/preonboarding/applyjob/service/ApplyJobService.java
+++ b/src/main/java/com/wanted/preonboarding/applyjob/service/ApplyJobService.java
@@ -1,0 +1,47 @@
+package com.wanted.preonboarding.applyjob.service;
+
+import com.wanted.preonboarding.applyjob.dto.request.ApplyJobCreateRequest;
+import com.wanted.preonboarding.applyjob.entity.ApplyJob;
+import com.wanted.preonboarding.applyjob.repository.ApplyJobRepository;
+import com.wanted.preonboarding.common.exception.ApplicationException;
+import com.wanted.preonboarding.common.exception.ErrorCode;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
+import com.wanted.preonboarding.jobpost.repository.JobPostRepository;
+import com.wanted.preonboarding.member.entity.Member;
+import com.wanted.preonboarding.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ApplyJobService {
+    private final ApplyJobRepository applyJobRepository;
+    private final JobPostRepository jobPostRepository;
+    private final MemberRepository memberRepository;
+
+    public ApplyJobService(final ApplyJobRepository applyJobRepository, final JobPostRepository jobPostRepository,
+                           final MemberRepository memberRepository) {
+        this.applyJobRepository = applyJobRepository;
+        this.jobPostRepository = jobPostRepository;
+        this.memberRepository = memberRepository;
+    }
+
+
+    @Transactional
+    public void applyJobPost(ApplyJobCreateRequest request) {
+        JobPost jobPost = jobPostRepository.findByIdAndIsDeletedFalse(request.getJobPostId())
+                                           .orElseThrow(() -> new ApplicationException(ErrorCode.JOBPOST_NOT_FOUND));
+        Member member = memberRepository.findById(request.getMemberId())
+                                        .orElseThrow(() -> new ApplicationException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if(applyJobRepository.findByJobPostAndMember(jobPost, member).isPresent()) {
+            throw new ApplicationException(ErrorCode.ALREADY_APPLY_JOBPOST);
+        }
+
+        ApplyJob applyJob = ApplyJob.builder()
+                                    .jobPost(jobPost)
+                                    .member(member)
+                                    .build();
+
+        applyJobRepository.save(applyJob);
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/common/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/preonboarding/common/exception/ErrorCode.java
@@ -10,12 +10,14 @@ public enum ErrorCode {
     UNABLE_TO_UPDATE_FIELDS(HttpStatus.BAD_REQUEST, "1000", "수정할 수 없는 필드가 있습니다"),
 
     // member 2000 ~
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "2000", "해당 사용자를 찾을 수 없습니다"),
 
     // company 3000 ~
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "3000", "해당 회사를 찾을 수 없습니다"),
 
     // job post 4000 ~
-    JOBPOST_NOT_FOUND(HttpStatus.NOT_FOUND, "4000", "해당 채용 공고를 찾을 수 없습니다");
+    JOBPOST_NOT_FOUND(HttpStatus.NOT_FOUND, "4000", "해당 채용 공고를 찾을 수 없습니다"),
+    ALREADY_APPLY_JOBPOST(HttpStatus.BAD_REQUEST, "4001", "이미 해당 채용 공고에 지원했습니다");
 
     private final HttpStatus status;
     private final String code; // 클라이언트 구분용 code

--- a/src/main/java/com/wanted/preonboarding/member/repository/MemberRepository.java
+++ b/src/main/java/com/wanted/preonboarding/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.preonboarding.member.repository;
+
+import com.wanted.preonboarding.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/test/java/com/wanted/preonboarding/applyjob/ApplyJobFixture.java
+++ b/src/test/java/com/wanted/preonboarding/applyjob/ApplyJobFixture.java
@@ -1,0 +1,26 @@
+package com.wanted.preonboarding.applyjob;
+
+import com.wanted.preonboarding.applyjob.dto.request.ApplyJobCreateRequest;
+import com.wanted.preonboarding.applyjob.entity.ApplyJob;
+import com.wanted.preonboarding.jobpost.JobPostFixture;
+import com.wanted.preonboarding.member.MemberFixture;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ApplyJobFixture {
+
+    private static ApplyJob APPLY_JOB1 = ApplyJob.builder()
+                                               .jobPost(JobPostFixture.JOBPOST_WANTED1())
+                                               .member(MemberFixture.MEMBER_CHULSOO())
+                                               .build();
+
+    public static ApplyJobCreateRequest APPLY_JOB_CREATE_REQUEST1 = new ApplyJobCreateRequest(
+            JobPostFixture.JOBPOST_WANTED1().getId(), MemberFixture.MEMBER_CHULSOO().getId());
+
+
+    public static ApplyJob APPLY_JOB1() {
+        if (APPLY_JOB1.getId() == null) {
+            ReflectionTestUtils.setField(APPLY_JOB1, "id", 1L);
+        }
+        return APPLY_JOB1;
+    }
+}

--- a/src/test/java/com/wanted/preonboarding/applyjob/repository/ApplyJobRepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/applyjob/repository/ApplyJobRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.wanted.preonboarding.applyjob.repository;
+
+import com.wanted.preonboarding.applyjob.entity.ApplyJob;
+import com.wanted.preonboarding.common.RepositoryTest;
+import com.wanted.preonboarding.company.entity.Company;
+import com.wanted.preonboarding.company.repository.CompanyRepository;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
+import com.wanted.preonboarding.jobpost.repository.JobPostRepository;
+import com.wanted.preonboarding.member.entity.Member;
+import com.wanted.preonboarding.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class ApplyJobRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    private ApplyJobRepository applyJobRepository;
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @Autowired
+    private JobPostRepository jobPostRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Company company;
+    private JobPost jobPost;
+    private Member member;
+
+    @BeforeEach
+    void beforeEach() {
+        company = Company.builder()
+                         .name("카카오")
+                         .nation("한국")
+                         .region("경기도")
+                         .build();
+
+        jobPost = JobPost.builder()
+                         .company(company)
+                         .position("프론트엔드 개발")
+                         .reward(2500000L)
+                         .skills("JavaScript, React")
+                         .description("카카오에서 프론트엔드 개발자를 채용합니다.")
+                         .build();
+
+        member = Member.builder()
+                       .name("김철수")
+                       .build();
+    }
+
+    @Test
+    @DisplayName("채용 공고와 사용자로 채용 공고 지원 내역을 조회할 수 있다")
+    void findByJobPostAndMember() {
+        // given
+        companyRepository.save(company);
+        jobPostRepository.save(jobPost);
+        memberRepository.save(member);
+        ApplyJob applyJob = ApplyJob.builder()
+                                    .jobPost(jobPost)
+                                    .member(member)
+                                    .build();
+        applyJobRepository.save(applyJob);
+        entityManager.flush();
+
+        // when
+        Optional<ApplyJob> retrievedApplyJob = applyJobRepository.findByJobPostAndMember(jobPost, member);
+
+        // then
+        assertAll(
+                () -> assertThat(retrievedApplyJob.get().getJobPost()).isEqualTo(jobPost),
+                () -> assertThat(retrievedApplyJob.get().getMember()).isEqualTo(member)
+        );
+    }
+}

--- a/src/test/java/com/wanted/preonboarding/applyjob/service/ApplyJobServiceTest.java
+++ b/src/test/java/com/wanted/preonboarding/applyjob/service/ApplyJobServiceTest.java
@@ -4,6 +4,8 @@ import com.wanted.preonboarding.applyjob.ApplyJobFixture;
 import com.wanted.preonboarding.applyjob.dto.request.ApplyJobCreateRequest;
 import com.wanted.preonboarding.applyjob.entity.ApplyJob;
 import com.wanted.preonboarding.applyjob.repository.ApplyJobRepository;
+import com.wanted.preonboarding.common.exception.ApplicationException;
+import com.wanted.preonboarding.common.exception.ErrorCode;
 import com.wanted.preonboarding.jobpost.JobPostFixture;
 import com.wanted.preonboarding.jobpost.entity.JobPost;
 import com.wanted.preonboarding.jobpost.repository.JobPostRepository;
@@ -20,9 +22,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,8 +58,8 @@ class ApplyJobServiceTest {
         applyJobCreateRequest1 = ApplyJobFixture.APPLY_JOB_CREATE_REQUEST1;
     }
 
-    @DisplayName("채용 공고 지원 성공")
     @Test
+    @DisplayName("채용 공고 지원 성공")
     void applyJobPost() {
         // given
         Long jobPostId = jobPostWanted1.getId();
@@ -72,6 +77,74 @@ class ApplyJobServiceTest {
                 () -> verify(memberRepository).findById(memberId),
                 () -> verify(applyJobRepository).findByJobPostAndMember(jobPostWanted1, memberChulSoo),
                 () -> verify(applyJobRepository).save(any(ApplyJob.class))
+        );
+    }
+
+    @Test
+    @DisplayName("채용 공고 지원 실패 : 채용 공고가 존재 하지 않을 때")
+    void applyJobPost_Failure_JobPostNotFound() {
+        // given
+        Long jobPostId = jobPostWanted1.getId();
+        given(jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)).willReturn(Optional.empty());
+
+        // when
+        ApplicationException ex = assertThrows(ApplicationException.class,
+                () -> applyJobService.applyJobPost(applyJobCreateRequest1));
+
+        // then
+        assertAll(
+                () -> verify(jobPostRepository).findByIdAndIsDeletedFalse(jobPostId),
+                () -> verify(memberRepository, never()).findById(any(Long.class)),
+                () -> verify(applyJobRepository, never()).findByJobPostAndMember(any(JobPost.class), any(Member.class)),
+                () -> verify(applyJobRepository, never()).save(any(ApplyJob.class)),
+                () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.JOBPOST_NOT_FOUND)
+        );
+    }
+
+    @Test
+    @DisplayName("채용 공고 지원 실패 : 채용 공고는 존재하지만 사용자가 없을 때")
+    void applyJobPost_Failure_MemberNotFound() {
+        // given
+        Long jobPostId = jobPostWanted1.getId();
+        Long memberId = memberChulSoo.getId();
+        given(jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)).willReturn(Optional.of(jobPostWanted1));
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when
+        ApplicationException ex = assertThrows(ApplicationException.class,
+                () -> applyJobService.applyJobPost(applyJobCreateRequest1));
+
+        // then
+        assertAll(
+                () -> verify(jobPostRepository).findByIdAndIsDeletedFalse(jobPostId),
+                () -> verify(memberRepository).findById(memberId),
+                () -> verify(applyJobRepository, never()).findByJobPostAndMember(any(JobPost.class), any(Member.class)),
+                () -> verify(applyJobRepository, never()).save(any(ApplyJob.class)),
+                () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND)
+        );
+    }
+
+    @Test
+    @DisplayName("채용 공고 지원 실패 : 사용자가 해당 채용 공고에 이미 지원 했을 때")
+    void applyJobPost_Failure_AlreadyApplyJobPost() {
+        // given
+        Long jobPostId = jobPostWanted1.getId();
+        Long memberId = memberChulSoo.getId();
+        given(jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)).willReturn(Optional.of(jobPostWanted1));
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(memberChulSoo));
+        given(applyJobRepository.findByJobPostAndMember(jobPostWanted1, memberChulSoo)).willReturn(Optional.of(applyJob1));
+
+        // when
+        ApplicationException ex = assertThrows(ApplicationException.class,
+                () -> applyJobService.applyJobPost(applyJobCreateRequest1));
+
+        // then
+        assertAll(
+                () -> verify(jobPostRepository).findByIdAndIsDeletedFalse(jobPostId),
+                () -> verify(memberRepository).findById(memberId),
+                () -> verify(applyJobRepository).findByJobPostAndMember(jobPostWanted1, memberChulSoo),
+                () -> verify(applyJobRepository, never()).save(any(ApplyJob.class)),
+                () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ALREADY_APPLY_JOBPOST)
         );
     }
 }

--- a/src/test/java/com/wanted/preonboarding/applyjob/service/ApplyJobServiceTest.java
+++ b/src/test/java/com/wanted/preonboarding/applyjob/service/ApplyJobServiceTest.java
@@ -1,0 +1,77 @@
+package com.wanted.preonboarding.applyjob.service;
+
+import com.wanted.preonboarding.applyjob.ApplyJobFixture;
+import com.wanted.preonboarding.applyjob.dto.request.ApplyJobCreateRequest;
+import com.wanted.preonboarding.applyjob.entity.ApplyJob;
+import com.wanted.preonboarding.applyjob.repository.ApplyJobRepository;
+import com.wanted.preonboarding.jobpost.JobPostFixture;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
+import com.wanted.preonboarding.jobpost.repository.JobPostRepository;
+import com.wanted.preonboarding.member.MemberFixture;
+import com.wanted.preonboarding.member.entity.Member;
+import com.wanted.preonboarding.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApplyJobServiceTest {
+
+    @Mock
+    private ApplyJobRepository applyJobRepository;
+
+    @Mock
+    private JobPostRepository jobPostRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private ApplyJobService applyJobService;
+
+    private Member memberChulSoo;
+    private JobPost jobPostWanted1;
+    private ApplyJob applyJob1;
+    private ApplyJobCreateRequest applyJobCreateRequest1;
+
+    @BeforeEach
+    void beforeEach() {
+        memberChulSoo = MemberFixture.MEMBER_CHULSOO();
+        jobPostWanted1 = JobPostFixture.JOBPOST_WANTED1();
+        applyJob1 = ApplyJobFixture.APPLY_JOB1();
+        applyJobCreateRequest1 = ApplyJobFixture.APPLY_JOB_CREATE_REQUEST1;
+    }
+
+    @DisplayName("채용 공고 지원 성공")
+    @Test
+    void applyJobPost() {
+        // given
+        Long jobPostId = jobPostWanted1.getId();
+        Long memberId = memberChulSoo.getId();
+        given(jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)).willReturn(Optional.of(jobPostWanted1));
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(memberChulSoo));
+        given(applyJobRepository.findByJobPostAndMember(jobPostWanted1, memberChulSoo)).willReturn(Optional.empty());
+
+        // when
+        applyJobService.applyJobPost(applyJobCreateRequest1);
+
+        // then
+        assertAll(
+                () -> verify(jobPostRepository).findByIdAndIsDeletedFalse(jobPostId),
+                () -> verify(memberRepository).findById(memberId),
+                () -> verify(applyJobRepository).findByJobPostAndMember(jobPostWanted1, memberChulSoo),
+                () -> verify(applyJobRepository).save(any(ApplyJob.class))
+        );
+    }
+}

--- a/src/test/java/com/wanted/preonboarding/member/MemberFixture.java
+++ b/src/test/java/com/wanted/preonboarding/member/MemberFixture.java
@@ -1,0 +1,29 @@
+package com.wanted.preonboarding.member;
+
+import com.wanted.preonboarding.member.entity.Member;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class MemberFixture {
+
+    private static Member MEMBER_CHULSOO = Member.builder()
+                                                 .name("김철수")
+                                                 .build();
+
+    private static Member MEMBER_GILDONG = Member.builder()
+                                                 .name("홍길동")
+                                                 .build();
+
+    public static Member MEMBER_CHULSOO() {
+        if (MEMBER_CHULSOO.getId() == null) {
+            ReflectionTestUtils.setField(MEMBER_CHULSOO, "id", 1L);
+        }
+        return MEMBER_CHULSOO;
+    }
+
+    public static Member MEMBER_GILDONG() {
+        if (MEMBER_GILDONG.getId() == null) {
+            ReflectionTestUtils.setField(MEMBER_GILDONG, "id", 2L);
+        }
+        return MEMBER_CHULSOO;
+    }
+}

--- a/src/test/java/com/wanted/preonboarding/member/MemberFixture.java
+++ b/src/test/java/com/wanted/preonboarding/member/MemberFixture.java
@@ -24,6 +24,6 @@ public class MemberFixture {
         if (MEMBER_GILDONG.getId() == null) {
             ReflectionTestUtils.setField(MEMBER_GILDONG, "id", 2L);
         }
-        return MEMBER_CHULSOO;
+        return MEMBER_GILDONG;
     }
 }


### PR DESCRIPTION
## 📃 설명

- resolves #10 
- 

## 🔨 작업 내용

1. 채용 공고 지원 API 구현
    -  **사용자는 1회만 지원 가능한 조건** 채용 공고와 사용자로 채용 공고 지원 내역 조회하는 메서드 추가해서 조회시 존재하면 예외 발생 하도록 단순하게 구현
3. 채용 공고 지원 Service Layer 성공, 실패 단위 테스트 작성
4. ApplyJobRepository 채용 공고와 사용자로 채용 공고 지원 단건 조회 메서드 테스트 작성
    - findByJobPostAndMember

## 💬 기타 사항

- 로직 구현할 때 채용 공고 조회 메서드 `jobPostRepository.findByIdAndIsDeletedFalse`로 호출할 수 있도록 주의