### PR TITLE
feat: 채용 공고 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/wanted/preonboarding/jobpost/controller/JobPostController.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/controller/JobPostController.java
@@ -3,8 +3,10 @@ package com.wanted.preonboarding.jobpost.controller;
 import com.wanted.preonboarding.common.ApiResponse;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostCreateRequest;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostUpdateRequest;
+import com.wanted.preonboarding.jobpost.dto.response.JobPostResponse;
 import com.wanted.preonboarding.jobpost.service.JobPostService;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 public class JobPostController {
@@ -25,6 +28,11 @@ public class JobPostController {
     public ApiResponse<?> createJobPost(@RequestBody @Valid JobPostCreateRequest jobPostCreateRequest) {
         jobPostService.createJobPost(jobPostCreateRequest);
         return ApiResponse.succeed();
+    }
+
+    @GetMapping("/job-post")
+    public ApiResponse<List<JobPostResponse>> retrieveJobPostList() {
+        return ApiResponse.succeed(jobPostService.retrieveJobPostList());
     }
 
     @PutMapping("/job-post/{jobPostId}")

--- a/src/main/java/com/wanted/preonboarding/jobpost/dto/response/JobPostResponse.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/dto/response/JobPostResponse.java
@@ -1,0 +1,40 @@
+package com.wanted.preonboarding.jobpost.dto.response;
+
+import com.wanted.preonboarding.company.entity.Company;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
+import lombok.Getter;
+
+@Getter
+public class JobPostResponse {
+
+    private Long jobPostId;
+
+    private String name;
+
+    private String nation;
+
+    private String region;
+
+    private String position;
+
+    private Long reward;
+
+    private String skills;
+
+    private JobPostResponse(Long jobPostId, String name, String nation, String region,
+                           String position, Long reward, String skills) {
+        this.jobPostId = jobPostId;
+        this.name = name;
+        this.nation = nation;
+        this.region = region;
+        this.position = position;
+        this.reward = reward;
+        this.skills = skills;
+    }
+
+    public static JobPostResponse from(final JobPost jobPost) {
+        Company company = jobPost.getCompany();
+        return new JobPostResponse(jobPost.getId(), company.getName(), company.getNation(),
+                company.getRegion(), jobPost.getPosition(), jobPost.getReward(), jobPost.getSkills());
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/jobpost/entity/JobPost.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/entity/JobPost.java
@@ -61,7 +61,7 @@ public class JobPost extends BaseTimeEntity {
         this.position = newJobPost.position;
         this.reward = newJobPost.reward;
         this.skills = newJobPost.skills;
-        this.position = newJobPost.position;
+        this.description = newJobPost.description;
         return this;
     }
 }

--- a/src/main/java/com/wanted/preonboarding/jobpost/repository/JobPostRepository.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/repository/JobPostRepository.java
@@ -3,9 +3,13 @@ package com.wanted.preonboarding.jobpost.repository;
 import com.wanted.preonboarding.jobpost.entity.JobPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JobPostRepository extends JpaRepository<JobPost, Long>{
 
     Optional<JobPost> findByIdAndIsDeletedFalse(Long id);
+
+    List<JobPost> findAllByIsDeletedFalse();
+
 }

--- a/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
@@ -6,10 +6,14 @@ import com.wanted.preonboarding.company.entity.Company;
 import com.wanted.preonboarding.company.repository.CompanyRepository;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostCreateRequest;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostUpdateRequest;
+import com.wanted.preonboarding.jobpost.dto.response.JobPostResponse;
 import com.wanted.preonboarding.jobpost.entity.JobPost;
 import com.wanted.preonboarding.jobpost.repository.JobPostRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class JobPostService {
@@ -28,6 +32,12 @@ public class JobPostService {
 
         JobPost jobPost = request.toEntity(company);
         jobPostRepository.save(jobPost);
+    }
+
+    public List<JobPostResponse> retrieveJobPostList() {
+        return jobPostRepository.findAllByIsDeletedFalse().stream()
+                                .map(JobPostResponse::from)
+                                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/test/java/com/wanted/preonboarding/applyjob/repository/ApplyJobRepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/applyjob/repository/ApplyJobRepositoryTest.java
@@ -45,7 +45,7 @@ class ApplyJobRepositoryTest extends RepositoryTest {
         company = Company.builder()
                          .name("카카오")
                          .nation("한국")
-                         .region("경기도")
+                         .region("판교")
                          .build();
 
         jobPost = JobPost.builder()

--- a/src/test/java/com/wanted/preonboarding/company/CompanyFixture.java
+++ b/src/test/java/com/wanted/preonboarding/company/CompanyFixture.java
@@ -14,7 +14,7 @@ public class CompanyFixture {
     private static Company COMPANY_NAVER = Company.builder()
                                                   .name("네이버")
                                                   .nation("한국")
-                                                  .region("경기도")
+                                                  .region("판교")
                                                   .build();
 
     public static Company COMPANY_WANTED() {

--- a/src/test/java/com/wanted/preonboarding/jobpost/JobPostFixture.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/JobPostFixture.java
@@ -29,6 +29,14 @@ public class JobPostFixture {
                                                     .description("원티드랩에서 백엔드 주니어 개발자를 채용합니다.")
                                                     .build();
 
+    private static JobPost JOBPOST_WANTED2 = JobPost.builder()
+                                                    .company(CompanyFixture.COMPANY_WANTED())
+                                                    .position("프론트엔드 주니어 개발자")
+                                                    .reward(1000000L)
+                                                    .skills("Vue")
+                                                    .description("원티드랩에서 프론트엔드 주니어 개발자를 채용합니다.")
+                                                    .build();
+
     private static JobPost JOBPOST_NAVER1 = JobPost.builder()
                                                     .company(CompanyFixture.COMPANY_NAVER())
                                                     .position("백엔드 개발자")
@@ -37,6 +45,15 @@ public class JobPostFixture {
                                                     .description("네이버에서 백엔드 개발자(신입/경력)를 채용합니다.")
                                                     .build();
 
+    private static JobPost DELETED_JOBPOST_NAVER2 = JobPost.builder()
+                                                   .company(CompanyFixture.COMPANY_NAVER())
+                                                   .position("iOS 개발자")
+                                                   .reward(100000L)
+                                                   .skills("Swift")
+                                                   .description("네이버에서 iOS 개발자를 채용합니다.")
+                                                   .build();
+
+
     public static JobPost JOBPOST_WANTED1() {
         if (JOBPOST_WANTED1.getId() == null) {
             ReflectionTestUtils.setField(JOBPOST_WANTED1, "id", 1L);
@@ -44,10 +61,26 @@ public class JobPostFixture {
         return JOBPOST_WANTED1;
     }
 
+    public static JobPost JOBPOST_WANTED2() {
+        if (JOBPOST_WANTED2.getId() == null) {
+            ReflectionTestUtils.setField(JOBPOST_WANTED2, "id", 3L);
+        }
+        return JOBPOST_WANTED2;
+    }
+
+
     public static JobPost JOBPOST_NAVER1() {
         if (JOBPOST_NAVER1.getId() == null) {
             ReflectionTestUtils.setField(JOBPOST_NAVER1, "id", 2L);
         }
         return JOBPOST_NAVER1;
+    }
+
+    public static JobPost DELETED_JOBPOST_NAVER2() {
+        if (DELETED_JOBPOST_NAVER2.getId() == null) {
+            ReflectionTestUtils.setField(DELETED_JOBPOST_NAVER2, "id", 4L);
+            ReflectionTestUtils.setField(DELETED_JOBPOST_NAVER2, "isDeleted", true);
+        }
+        return DELETED_JOBPOST_NAVER2;
     }
 }

--- a/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
@@ -126,7 +126,7 @@ public class JobPostRepositoryTest extends RepositoryTest {
         // when
         List<JobPost> jobPostResponseList = jobPostRepository.findAllByIsDeletedFalse();
 
-        // then: 조회되지 않아야 한다
+        // then
         assertAll(
                 () -> assertThat(jobPostResponseList.size()).isEqualTo(3),
                 () -> assertThat(jobPostResponseList.get(1)).isEqualTo(jobPost2)

--- a/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,13 +30,16 @@ public class JobPostRepositoryTest extends RepositoryTest {
 
     private Company company;
     private JobPost jobPost;
+    private JobPost jobPost2;
+    private JobPost jobPost3;
+    private JobPost deletedJobPost;
 
     @BeforeEach
     void beforeEach() {
         company = Company.builder()
                          .name("카카오")
                          .nation("한국")
-                         .region("경기도")
+                         .region("판교")
                          .build();
 
         jobPost = JobPost.builder()
@@ -45,6 +49,30 @@ public class JobPostRepositoryTest extends RepositoryTest {
                          .skills("JavaScript, React")
                          .description("카카오에서 프론트엔드 개발자를 채용합니다.")
                          .build();
+
+        jobPost2 = JobPost.builder()
+                          .company(company)
+                          .position("백엔드 개발")
+                          .reward(2500000L)
+                          .skills("node.js")
+                          .description("카카오에서 백엔드 개발자를 채용합니다.")
+                          .build();
+
+        jobPost3 = JobPost.builder()
+                          .company(company)
+                          .position("데브옵스 엔지니어")
+                          .reward(2500000L)
+                          .skills("k8s, istio")
+                          .description("카카오에서 데브옵스 엔지니어를 채용합니다.")
+                          .build();
+
+        deletedJobPost = JobPost.builder()
+                                .company(company)
+                                .position("백엔드")
+                                .reward(500000L)
+                                .skills("Java, Spring")
+                                .description("카카오에서 Java&Spring 백엔드 개발자를 채용합니다.")
+                                .build();
     }
 
     @Test
@@ -83,5 +111,49 @@ public class JobPostRepositoryTest extends RepositoryTest {
 
         // then: 조회되지 않아야 한다
         assertThat(result.isEmpty()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("존재하는 채용 공고 목록 조회")
+    void findAllByIsDeletedFalse() {
+        // given
+        companyRepository.save(company);
+        jobPostRepository.save(jobPost);
+        jobPostRepository.save(jobPost2);
+        jobPostRepository.save(jobPost3);
+        entityManager.flush();
+
+        // when
+        List<JobPost> jobPostResponseList = jobPostRepository.findAllByIsDeletedFalse();
+
+        // then: 조회되지 않아야 한다
+        assertAll(
+                () -> assertThat(jobPostResponseList.size()).isEqualTo(3),
+                () -> assertThat(jobPostResponseList.get(1)).isEqualTo(jobPost2)
+        );
+    }
+
+
+
+
+
+
+
+    @Test
+    @DisplayName("존재하는 채용 공고 목록 조회에서 삭제된 채용 공고는 조회되지 않아야 한다")
+    void findAllByIsDeletedFalse_Empty() {
+        // given
+        companyRepository.save(company);
+        jobPostRepository.save(deletedJobPost);
+        jobPostRepository.delete(deletedJobPost);
+        entityManager.flush();
+
+        // when
+        List<JobPost> jobPostResponseList = jobPostRepository.findAllByIsDeletedFalse();
+
+        // then: 조회되지 않아야 한다
+        assertAll(
+                () -> assertThat(jobPostResponseList.isEmpty()).isTrue()
+        );
     }
 }

--- a/src/test/java/com/wanted/preonboarding/jobpost/service/JobPostServiceTest.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/service/JobPostServiceTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -68,8 +67,8 @@ class JobPostServiceTest {
         jobPostUpdateRequestNaver1 = JobPostFixture.JOBPOST_UPDATE_REQUEST_NAVER1;
     }
 
-    @DisplayName("채용 공고 생성 성공")
     @Test
+    @DisplayName("채용 공고 생성 성공")
     void createJobPost() {
         // given: 생성 요청 필드가 유효하고 companyId에 해당하는 회사가 존재하도록 설정
         Long companyId = jobPostCreateRequestWanted1.getCompanyId();
@@ -85,8 +84,8 @@ class JobPostServiceTest {
         );
     }
 
-    @DisplayName("채용 공고 생성 실패 : companyId에 해당하는 회사가 존재하지 않을 때")
     @Test
+    @DisplayName("채용 공고 생성 실패 : companyId에 해당하는 회사가 존재하지 않을 때")
     void createJobPost_Failure_CompanyNotFound() {
         // given: 생성 요청 필드는 유효하지만 companyId에 해당하는 회사가 존재하지 않도록 설정
         Long companyId = jobPostCreateRequestWanted1.getCompanyId();
@@ -101,12 +100,12 @@ class JobPostServiceTest {
         assertAll(
                 () -> verify(companyRepository).findById(companyId),
                 () -> verify(jobPostRepository, never()).save(any(JobPost.class)),
-                () -> assertEquals(ErrorCode.COMPANY_NOT_FOUND, ex.getErrorCode())
+                () -> assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.COMPANY_NOT_FOUND)
         );
     }
 
-    @DisplayName("채용 공고 목록 조회 성공")
     @Test
+    @DisplayName("채용 공고 목록 조회 성공")
     void retrieveJobPostList() {
         // given
         List<JobPost> jobPostList = new ArrayList<>();
@@ -131,8 +130,8 @@ class JobPostServiceTest {
         );
     }
 
-    @DisplayName("채용 공고 목록 조회 성공 : 없으면 빈 List 반환")
     @Test
+    @DisplayName("채용 공고 목록 조회 성공 : 없으면 빈 List 반환")
     void retrieveJobPostList_Empty() {
         // given
         List<JobPost> jobPostList = new ArrayList<>();
@@ -148,8 +147,8 @@ class JobPostServiceTest {
         );
     }
 
-    @DisplayName("채용 공고 수정 성공")
     @Test
+    @DisplayName("채용 공고 수정 성공")
     void updateJobPost() {
         // given: 수정 요청에서 companyId는 변경되지 않고 그 외 필드는 유효하도록 설정
         Long jobPostId = jobPostWanted1.getId();
@@ -165,8 +164,8 @@ class JobPostServiceTest {
         );
     }
 
-    @DisplayName("채용 공고 수정 실패 : 수정하려는 채용 공고가 없을 때")
     @Test
+    @DisplayName("채용 공고 수정 실패 : 수정하려는 채용 공고가 없을 때")
     void updateJobPost_Failure_AlreadyDeletedJobpost() {
         // given: 수정 요청에서 companyId는 변경되지 않고 그 외 필드는 유효하지만 존재하지 않은 채용 공고 id 설정
         Long jobPostId = 357523L;
@@ -184,8 +183,8 @@ class JobPostServiceTest {
         );
     }
 
-    @DisplayName("채용 공고 수정 실패 : 채용 공고의 company_id 필드를 수정하려 할 때")
     @Test
+    @DisplayName("채용 공고 수정 실패 : 채용 공고의 company_id 필드를 수정하려 할 때")
     void updateJobPost_Failure_UnableToUpdateFields() {
         // given: 채용 공고의 companyId와 다른 companyId를 가진 수정 요청 설정
         JobPost jobPost = jobPostWanted1;
@@ -206,8 +205,8 @@ class JobPostServiceTest {
         );
     }
 
-    @DisplayName("채용 공고 삭제 성공")
     @Test
+    @DisplayName("채용 공고 삭제 성공")
     void deleteJobPost() {
         // given
         Long jobPostId = jobPostNaver1.getId();
@@ -223,9 +222,9 @@ class JobPostServiceTest {
         );
     }
 
-    @DisplayName("채용 공고 삭제 실패 : 채용 공고가 존재하지 않을 때")
     @Test
-    void deleteJobPost_Failure_JOBPOST_NOT_FOUND() {
+    @DisplayName("채용 공고 삭제 실패 : 채용 공고가 존재하지 않을 때")
+    void deleteJobPost_Failure_JobPostNotFound() {
         // given
         Long jobPostId = 234234L;
         given(jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)).willReturn(Optional.empty());


### PR DESCRIPTION
## 📃 설명

- resolves #7 
- 

## 🔨 작업 내용

1. 채용 공고 목록 조회 구현
2. 채용 공고 목록 조회 Service Layer 단위 테스트 작성
    - 채용 공고 없을 경우 비어있는 List 반환하기에 따로 exception 발생하는 실패 테스트는 없음
3. JobPostRepository 존재하는 채용 공고 목록 조회 함수 `findAllByIsDeletedFalse` 테스트 작성
4. JobPost entity update 함수 오타 수정
    - description 대입이 아닌 position 대입 코드만 2개 있어서 수정

## 💬 기타 사항

- 