### PR TITLE
feat: 채용 상세 페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/wanted/preonboarding/company/entity/Company.java
+++ b/src/main/java/com/wanted/preonboarding/company/entity/Company.java
@@ -1,6 +1,7 @@
 package com.wanted.preonboarding.company.entity;
 
 import com.wanted.preonboarding.common.entity.BaseTimeEntity;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -9,9 +10,13 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -31,6 +36,9 @@ public class Company extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String region;
+
+    @OneToMany(mappedBy = "company", fetch = FetchType.LAZY)
+    private List<JobPost> jobPostList = new ArrayList<>();
 
     @Builder
     public Company(String name, String nation, String region) {

--- a/src/main/java/com/wanted/preonboarding/jobpost/controller/JobPostController.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/controller/JobPostController.java
@@ -3,6 +3,7 @@ package com.wanted.preonboarding.jobpost.controller;
 import com.wanted.preonboarding.common.ApiResponse;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostCreateRequest;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostUpdateRequest;
+import com.wanted.preonboarding.jobpost.dto.response.JobPostDetailResponse;
 import com.wanted.preonboarding.jobpost.dto.response.JobPostResponse;
 import com.wanted.preonboarding.jobpost.service.JobPostService;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -33,6 +34,11 @@ public class JobPostController {
     @GetMapping("/job-post")
     public ApiResponse<List<JobPostResponse>> retrieveJobPostList() {
         return ApiResponse.succeed(jobPostService.retrieveJobPostList());
+    }
+
+    @GetMapping("/job-post/{jobPostId}")
+    public ApiResponse<JobPostDetailResponse> retrieveJobPostDetail(@PathVariable Long jobPostId) {
+        return ApiResponse.succeed(jobPostService.retrieveJobPostDetail(jobPostId));
     }
 
     @PutMapping("/job-post/{jobPostId}")

--- a/src/main/java/com/wanted/preonboarding/jobpost/dto/response/JobPostDetailResponse.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/dto/response/JobPostDetailResponse.java
@@ -1,0 +1,48 @@
+package com.wanted.preonboarding.jobpost.dto.response;
+
+import com.wanted.preonboarding.company.entity.Company;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class JobPostDetailResponse {
+
+    private Long jobPostId;
+
+    private String companyName;
+
+    private String nation;
+
+    private String region;
+
+    private String position;
+
+    private Long reward;
+
+    private String skills;
+
+    private String description;
+
+    private List<Long> companyOtherJobPostList;
+
+    private JobPostDetailResponse(Long jobPostId, String companyName, String nation, String region, String position,
+                                  Long reward, String skills, String description, List<Long> companyOtherJobPostList) {
+        this.jobPostId = jobPostId;
+        this.companyName = companyName;
+        this.nation = nation;
+        this.region = region;
+        this.position = position;
+        this.reward = reward;
+        this.skills = skills;
+        this.description = description;
+        this.companyOtherJobPostList = companyOtherJobPostList;
+    }
+
+    public static JobPostDetailResponse of(final JobPost jobPost, List<Long> companyOtherJobPostList) {
+        Company company = jobPost.getCompany();
+        return new JobPostDetailResponse(jobPost.getId(), company.getName(), company.getNation(),
+                company.getRegion(), jobPost.getPosition(), jobPost.getReward(),
+                jobPost.getSkills(), jobPost.getDescription(), companyOtherJobPostList);
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/jobpost/dto/response/JobPostResponse.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/dto/response/JobPostResponse.java
@@ -9,7 +9,7 @@ public class JobPostResponse {
 
     private Long jobPostId;
 
-    private String name;
+    private String companyName;
 
     private String nation;
 
@@ -21,10 +21,10 @@ public class JobPostResponse {
 
     private String skills;
 
-    private JobPostResponse(Long jobPostId, String name, String nation, String region,
-                           String position, Long reward, String skills) {
+    private JobPostResponse(Long jobPostId, String companyName, String nation, String region,
+                            String position, Long reward, String skills) {
         this.jobPostId = jobPostId;
-        this.name = name;
+        this.companyName = companyName;
         this.nation = nation;
         this.region = region;
         this.position = position;

--- a/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
@@ -6,6 +6,7 @@ import com.wanted.preonboarding.company.entity.Company;
 import com.wanted.preonboarding.company.repository.CompanyRepository;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostCreateRequest;
 import com.wanted.preonboarding.jobpost.dto.request.JobPostUpdateRequest;
+import com.wanted.preonboarding.jobpost.dto.response.JobPostDetailResponse;
 import com.wanted.preonboarding.jobpost.dto.response.JobPostResponse;
 import com.wanted.preonboarding.jobpost.entity.JobPost;
 import com.wanted.preonboarding.jobpost.repository.JobPostRepository;
@@ -38,6 +39,18 @@ public class JobPostService {
         return jobPostRepository.findAllByIsDeletedFalse().stream()
                                 .map(JobPostResponse::from)
                                 .collect(Collectors.toList());
+    }
+
+    public JobPostDetailResponse retrieveJobPostDetail(Long jobPostId) {
+        JobPost jobPost = jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)
+                                           .orElseThrow(() -> new ApplicationException(ErrorCode.JOBPOST_NOT_FOUND));
+
+        List<Long> companyOtherJobPostList = jobPost.getCompany().getJobPostList().stream()
+                                                    .filter(jp -> !jp.isDeleted())
+                                                    .map(JobPost::getId)
+                                                    .collect(Collectors.toList());
+
+        return JobPostDetailResponse.of(jobPost, companyOtherJobPostList);
     }
 
     @Transactional

--- a/src/test/java/com/wanted/preonboarding/applyjob/ApplyJobFixture.java
+++ b/src/test/java/com/wanted/preonboarding/applyjob/ApplyJobFixture.java
@@ -18,9 +18,10 @@ public class ApplyJobFixture {
 
 
     public static ApplyJob APPLY_JOB1() {
-        if (APPLY_JOB1.getId() == null) {
-            ReflectionTestUtils.setField(APPLY_JOB1, "id", 1L);
+        ApplyJob applyJob = APPLY_JOB1;
+        if (applyJob.getId() == null) {
+            ReflectionTestUtils.setField(applyJob, "id", 1L);
         }
-        return APPLY_JOB1;
+        return applyJob;
     }
 }

--- a/src/test/java/com/wanted/preonboarding/company/CompanyFixture.java
+++ b/src/test/java/com/wanted/preonboarding/company/CompanyFixture.java
@@ -1,7 +1,10 @@
 package com.wanted.preonboarding.company;
 
 import com.wanted.preonboarding.company.entity.Company;
+import com.wanted.preonboarding.jobpost.entity.JobPost;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
 
 public class CompanyFixture {
 
@@ -13,6 +16,12 @@ public class CompanyFixture {
 
     private static Company COMPANY_NAVER = Company.builder()
                                                   .name("네이버")
+                                                  .nation("한국")
+                                                  .region("판교")
+                                                  .build();
+
+    private static Company COMPANY_NEXON = Company.builder()
+                                                  .name("넥슨")
                                                   .nation("한국")
                                                   .region("판교")
                                                   .build();
@@ -29,5 +38,58 @@ public class CompanyFixture {
             ReflectionTestUtils.setField(COMPANY_NAVER, "id", 2L);
         }
         return COMPANY_NAVER;
+    }
+
+    /**
+     * <p>{@link JobPost} 와 {@link Company}가 N:1 연관 관계이고 만약 Company가 JobPost1, JobPost2, JobPost3를 생성했을 때
+     *
+     * <p>JobPost1 초기화시 Company가 필요해서 CompanyFixture.COMPANY_XXX()를 호출
+     *
+     * <p>Company 초기화할 때 JobPostList에 JobPost1, 2, 3 데이터를 저장하는데 JobPost2, 3는 아직 생성하지 않았고
+     * 생성하기 위해서는 또 다시 Company가 필요해서 {@link java.lang.ExceptionInInitializerError} 발생
+     *
+     * <p>회사가 올린 다른 채용 공고(JobPostList)를 사용하는 테스트를 위해 Fixture에 선언된 JobPost가 아닌
+     * 바로 JobPost를 생성해서 JobPostList 셋팅한 Company entity class
+     * @return 회사 이름 Nexon인 Company entity
+     */
+    public static Company COMPANY_NEXON() {
+        Company company = COMPANY_NEXON;
+        if (company.getId() == null) {
+            ReflectionTestUtils.setField(company, "id", 3L);
+
+            JobPost jobPost10500 = JobPost.builder()
+                                          .company(company)
+                                          .position("게임 클라이언트 개발자")
+                                          .reward(1500000L)
+                                          .skills("C#, Unity")
+                                          .description("넥슨에서 게임 클라이언트 개발자를 채용합니다.")
+                                          .build();
+
+            JobPost deletedJobPost10501 = JobPost.builder()
+                                                 .company(company)
+                                                 .position("게임 서버 개발자")
+                                                 .reward(1500000L)
+                                                 .skills("C++")
+                                                 .description("넥슨에서 게임 서버 개발자를 채용합니다.")
+                                                 .build();
+
+            JobPost jobPost10502 = JobPost.builder()
+                                          .company(company)
+                                          .position("웹 백엔드 엔지니어")
+                                          .reward(1500000L)
+                                          .skills("C#, ASP.NET")
+                                          .description("넥슨에서 웹 백엔드 엔지니어를 채용합니다.")
+                                          .build();
+
+            ReflectionTestUtils.setField(jobPost10500, "id", 10500L);
+            ReflectionTestUtils.setField(deletedJobPost10501, "id", 10501L);
+            ReflectionTestUtils.setField(deletedJobPost10501, "isDeleted", true);
+            ReflectionTestUtils.setField(jobPost10502, "id", 10502L);
+
+            ReflectionTestUtils.setField(company, "jobPostList", Arrays.asList(
+                    jobPost10500, deletedJobPost10501, jobPost10502
+            ));
+        }
+        return company;
     }
 }

--- a/src/test/java/com/wanted/preonboarding/company/CompanyFixture.java
+++ b/src/test/java/com/wanted/preonboarding/company/CompanyFixture.java
@@ -27,17 +27,19 @@ public class CompanyFixture {
                                                   .build();
 
     public static Company COMPANY_WANTED() {
-        if (COMPANY_WANTED.getId() == null) {
-            ReflectionTestUtils.setField(COMPANY_WANTED, "id", 1L);
+        Company company = COMPANY_WANTED;
+        if (company.getId() == null) {
+            ReflectionTestUtils.setField(company, "id", 1L);
         }
-        return COMPANY_WANTED;
+        return company;
     }
 
     public static Company COMPANY_NAVER() {
-        if (COMPANY_NAVER.getId() == null) {
-            ReflectionTestUtils.setField(COMPANY_NAVER, "id", 2L);
+        Company company = COMPANY_NAVER;
+        if (company.getId() == null) {
+            ReflectionTestUtils.setField(company, "id", 2L);
         }
-        return COMPANY_NAVER;
+        return company;
     }
 
     /**

--- a/src/test/java/com/wanted/preonboarding/jobpost/JobPostFixture.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/JobPostFixture.java
@@ -71,47 +71,53 @@ public class JobPostFixture {
 
 
     public static JobPost JOBPOST_WANTED1() {
-        if (JOBPOST_WANTED1.getId() == null) {
-            ReflectionTestUtils.setField(JOBPOST_WANTED1, "id", 1L);
+        JobPost jobPost = JOBPOST_WANTED1;
+        if (jobPost.getId() == null) {
+            ReflectionTestUtils.setField(jobPost, "id", 1L);
         }
-        return JOBPOST_WANTED1;
+        return jobPost;
     }
 
     public static JobPost JOBPOST_WANTED2() {
-        if (JOBPOST_WANTED2.getId() == null) {
-            ReflectionTestUtils.setField(JOBPOST_WANTED2, "id", 3L);
+        JobPost jobPost = JOBPOST_WANTED2;
+        if (jobPost.getId() == null) {
+            ReflectionTestUtils.setField(jobPost, "id", 3L);
         }
-        return JOBPOST_WANTED2;
+        return jobPost;
     }
 
     public static JobPost JOBPOST_NEXON1() {
-        if (JOBPOST_NEXON1.getId() == null) {
-            ReflectionTestUtils.setField(JOBPOST_NEXON1, "id", 10500L);
+        JobPost jobPost = JOBPOST_NEXON1;
+        if (jobPost.getId() == null) {
+            ReflectionTestUtils.setField(jobPost, "id", 10500L);
         }
-        return JOBPOST_NEXON1;
+        return jobPost;
     }
 
     public static JobPost DELETED_JOBPOST_NEXON2() {
-        if (DELETED_JOBPOST_NEXON2.getId() == null) {
-            ReflectionTestUtils.setField(DELETED_JOBPOST_NEXON2, "id", 10501L);
-            ReflectionTestUtils.setField(DELETED_JOBPOST_NAVER2, "isDeleted", true);
+        JobPost jobPost = DELETED_JOBPOST_NEXON2;
+        if (jobPost.getId() == null) {
+            ReflectionTestUtils.setField(jobPost, "id", 10501L);
+            ReflectionTestUtils.setField(jobPost, "isDeleted", true);
         }
-        return DELETED_JOBPOST_NEXON2;
+        return jobPost;
     }
 
 
     public static JobPost JOBPOST_NAVER1() {
-        if (JOBPOST_NAVER1.getId() == null) {
-            ReflectionTestUtils.setField(JOBPOST_NAVER1, "id", 2L);
+        JobPost jobPost = JOBPOST_NAVER1;
+        if (jobPost.getId() == null) {
+            ReflectionTestUtils.setField(jobPost, "id", 2L);
         }
-        return JOBPOST_NAVER1;
+        return jobPost;
     }
 
     public static JobPost DELETED_JOBPOST_NAVER2() {
-        if (DELETED_JOBPOST_NAVER2.getId() == null) {
-            ReflectionTestUtils.setField(DELETED_JOBPOST_NAVER2, "id", 4L);
-            ReflectionTestUtils.setField(DELETED_JOBPOST_NAVER2, "isDeleted", true);
+        JobPost jobPost = DELETED_JOBPOST_NAVER2;
+        if (jobPost.getId() == null) {
+            ReflectionTestUtils.setField(jobPost, "id", 4L);
+            ReflectionTestUtils.setField(jobPost, "isDeleted", true);
         }
-        return DELETED_JOBPOST_NAVER2;
+        return jobPost;
     }
 }

--- a/src/test/java/com/wanted/preonboarding/jobpost/JobPostFixture.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/JobPostFixture.java
@@ -45,6 +45,22 @@ public class JobPostFixture {
                                                     .description("네이버에서 백엔드 개발자(신입/경력)를 채용합니다.")
                                                     .build();
 
+    private static JobPost JOBPOST_NEXON1 = JobPost.builder()
+                                                   .company(CompanyFixture.COMPANY_NEXON())
+                                                   .position("게임 클라이언트 개발자")
+                                                   .reward(1500000L)
+                                                   .skills("C#, Unity")
+                                                   .description("넥슨에서 게임 클라이언트 개발자를 채용합니다.")
+                                                   .build();
+
+    private static JobPost DELETED_JOBPOST_NEXON2 = JobPost.builder()
+                                                           .company(CompanyFixture.COMPANY_NEXON())
+                                                           .position("게임 클라이언트 개발자")
+                                                           .reward(1500000L)
+                                                           .skills("C#, Unity")
+                                                           .description("넥슨에서 게임 클라이언트 개발자를 채용합니다.")
+                                                           .build();
+
     private static JobPost DELETED_JOBPOST_NAVER2 = JobPost.builder()
                                                    .company(CompanyFixture.COMPANY_NAVER())
                                                    .position("iOS 개발자")
@@ -66,6 +82,21 @@ public class JobPostFixture {
             ReflectionTestUtils.setField(JOBPOST_WANTED2, "id", 3L);
         }
         return JOBPOST_WANTED2;
+    }
+
+    public static JobPost JOBPOST_NEXON1() {
+        if (JOBPOST_NEXON1.getId() == null) {
+            ReflectionTestUtils.setField(JOBPOST_NEXON1, "id", 10500L);
+        }
+        return JOBPOST_NEXON1;
+    }
+
+    public static JobPost DELETED_JOBPOST_NEXON2() {
+        if (DELETED_JOBPOST_NEXON2.getId() == null) {
+            ReflectionTestUtils.setField(DELETED_JOBPOST_NEXON2, "id", 10501L);
+            ReflectionTestUtils.setField(DELETED_JOBPOST_NAVER2, "isDeleted", true);
+        }
+        return DELETED_JOBPOST_NEXON2;
     }
 
 

--- a/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/repository/JobPostRepositoryTest.java
@@ -133,12 +133,6 @@ public class JobPostRepositoryTest extends RepositoryTest {
         );
     }
 
-
-
-
-
-
-
     @Test
     @DisplayName("존재하는 채용 공고 목록 조회에서 삭제된 채용 공고는 조회되지 않아야 한다")
     void findAllByIsDeletedFalse_Empty() {
@@ -154,6 +148,31 @@ public class JobPostRepositoryTest extends RepositoryTest {
         // then: 조회되지 않아야 한다
         assertAll(
                 () -> assertThat(jobPostResponseList.isEmpty()).isTrue()
+        );
+    }
+
+    @Test
+    @DisplayName("Company의 jobPostList(회사가 올린 다른 채용 공고)에는 삭제 여부 상관없이 데이터가 있어야 한다")
+    void jobPostListTest() {
+        // given: 존재하는 채용 공고 3개, 삭제한 채용 공고 1개 설정
+        companyRepository.save(company);
+        jobPostRepository.save(jobPost);
+        jobPostRepository.save(jobPost2);
+        jobPostRepository.save(jobPost3);
+        jobPostRepository.save(deletedJobPost);
+        jobPostRepository.delete(deletedJobPost);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when: 존재하는(삭제하지 않은) 채용 공고로 조회하고 company의 jobPostList 확인
+        JobPost jobPost = jobPostRepository.findByIdAndIsDeletedFalse(jobPost2.getId()).get();
+
+        // then: 존재하는 채용 공고 3개, 삭제한 채용 공고 1개 List의 총 4개의 채용 공고가 있어야함
+        assertAll(
+                () -> assertThat(jobPost.getCompany().getJobPostList().size()).isEqualTo(4),
+                () -> assertThat(jobPost).isEqualTo(jobPost2),
+                () -> assertThat(jobPost.getCompany().getJobPostList().get(1)).isEqualTo(jobPost2),
+                () -> assertThat(jobPost.getCompany().getJobPostList().get(3).isDeleted()).isTrue()
         );
     }
 }

--- a/src/test/java/com/wanted/preonboarding/jobpost/service/JobPostServiceTest.java
+++ b/src/test/java/com/wanted/preonboarding/jobpost/service/JobPostServiceTest.java
@@ -126,7 +126,7 @@ class JobPostServiceTest {
                 () -> {
                     JobPostResponse jobPostResponse = result.get(1);
                     assertThat(jobPostResponse.getJobPostId()).isEqualTo(jobPostNaver1.getId());
-                    assertThat(jobPostResponse.getName()).isEqualTo(jobPostNaver1.getCompany().getName());
+                    assertThat(jobPostResponse.getCompanyName()).isEqualTo(jobPostNaver1.getCompany().getName());
                     assertThat(jobPostResponse.getPosition()).isEqualTo(jobPostNaver1.getPosition());
                 }
         );

--- a/src/test/java/com/wanted/preonboarding/member/MemberFixture.java
+++ b/src/test/java/com/wanted/preonboarding/member/MemberFixture.java
@@ -14,16 +14,18 @@ public class MemberFixture {
                                                  .build();
 
     public static Member MEMBER_CHULSOO() {
-        if (MEMBER_CHULSOO.getId() == null) {
-            ReflectionTestUtils.setField(MEMBER_CHULSOO, "id", 1L);
+        Member member = MEMBER_CHULSOO;
+        if (member.getId() == null) {
+            ReflectionTestUtils.setField(member, "id", 1L);
         }
-        return MEMBER_CHULSOO;
+        return member;
     }
 
     public static Member MEMBER_GILDONG() {
-        if (MEMBER_GILDONG.getId() == null) {
-            ReflectionTestUtils.setField(MEMBER_GILDONG, "id", 2L);
+        Member member = MEMBER_GILDONG;
+        if (member.getId() == null) {
+            ReflectionTestUtils.setField(member, "id", 2L);
         }
-        return MEMBER_GILDONG;
+        return member;
     }
 }


### PR DESCRIPTION
## 📃 설명

- resolves #9 
- 

## 🔨 작업 내용

1. 채용 공고 상세 페이지 조회 구현
    - `GET /job-post/{jobPostId}`
3. 상세 페이지 응답 dto에 채용 내용 (description) 추가
4. 응답에 해당 회사가 올린 다른 채용 공고 추가하기
3.1 Company entity에서 회사가 올린 다른 채용 공고 목록 선언
(n대1 연관 관계에서 n이 관계의 주인일 때 1에 해당하는 entity에서는 `@OneToMany(mappedBy = "n에서 fk랑 매칭된 변수")` 으로 연관 관계 선언)
``` java
// Company.class
@OneToMany(mappedBy = "company", fetch = FetchType.LAZY)
private List<JobPost> jobPostList = new ArrayList<>();
```

  3.2 soft delete 구현 특징상 삭제된(isDeleted = true) 채용 공고 필터링하고 요구조건인 채용공고Id로 변환
``` java
// JobPostService.class retrieveJobPostDetail 함수 본문 중 일부
List<Long> companyOtherJobPostList = jobPost.getCompany().getJobPostList().stream()
                                                    .filter(jp -> !jp.isDeleted())
                                                    .map(JobPost::getId)
                                                    .collect(Collectors.toList());
```
6. 채용 상세 페이지 조회 Service Layer 단위 테스트 작성
    - 성공, 실패 단위 테스트 작성
    - 존재하지 않은(삭제된) 채용 공고로 상세 페이지 조회할 때 실패(예외 처리)
8. 채용 공고 목록 조회 응답 dto 회사 이름 변수명 name -> companyName으로 변경
9. JobPostRepository에서 Company의 jobPostList 테스트
    -  Service layer에서 삭제된 채용 공고를 필터링 할거라 Company entity의 **해당 회사가 올린 다른 채용 공고(jobPostList)** List는 삭제 여부 상관없이 해당 회사가 올린 모든 채용 공고가 조회 되어야함

## 💬 기타 사항

- 