### PR TITLE
fix: 채용 공고 조회 API 호출 시 에러 수정

### DIFF
--- a/src/main/java/com/wanted/preonboarding/common/ApiResponse.java
+++ b/src/main/java/com/wanted/preonboarding/common/ApiResponse.java
@@ -1,7 +1,9 @@
 package com.wanted.preonboarding.common;
 
 import com.wanted.preonboarding.common.exception.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public class ApiResponse<T> {
     private final boolean success;
     private final T response;

--- a/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
+++ b/src/main/java/com/wanted/preonboarding/jobpost/service/JobPostService.java
@@ -41,6 +41,7 @@ public class JobPostService {
                                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public JobPostDetailResponse retrieveJobPostDetail(Long jobPostId) {
         JobPost jobPost = jobPostRepository.findByIdAndIsDeletedFalse(jobPostId)
                                            .orElseThrow(() -> new ApplicationException(ErrorCode.JOBPOST_NOT_FOUND));


### PR DESCRIPTION
## 📃 설명

- fix #18 
- 

## 🔨 작업 내용

1. HttpMediaTypeNotAcceptableException 해결
    - API 응답 클래스에 `@Getter` 추가
    - 핸들러 메소드가 클라이언트가 요청한 type으로 응답으로 내려줄 수 없을 때 발생
3. LazyInitializationException 해결
    - JobPostService.retrieveJobPostDetail 함수 `@Transactional(readOnly = true)` 추가

## 💬 기타 사항

- 